### PR TITLE
Allow specifying cert locations

### DIFF
--- a/client.py
+++ b/client.py
@@ -3,5 +3,9 @@
 import redis
 import os
 
-conn = redis.StrictRedis(host=os.environ.get("REDIS_HOST"), port=int(os.environ.get("REDIS_PORT", 6401)), ssl=True, ssl_cert_reqs=None, ssl_ca_certs="/etc/redis/ssl/ca.crt", ssl_keyfile="/etc/redis/ssl/server.key", ssl_certfile="/etc/redis/ssl/server.crt")
+cacert = os.environ.get("REDIS_SSL_DIR", "/etc/redis/ssl") + "/ca.crt"
+sslkeyfile = os.environ.get("REDIS_SSL_DIR", "/etc/redis/ssl") + "/server.key"
+sslcert = os.environ.get("REDIS_SSL_DIR", "/etc/redis/ssl") + "/server.crt"
+
+conn = redis.StrictRedis(host=os.environ.get("REDIS_HOST"), port=int(os.environ.get("REDIS_PORT", 6401)), ssl=True, ssl_cert_reqs=None, ssl_ca_certs=cacert, ssl_keyfile=sslkeyfile, ssl_certfile=sslcert)
 print("Pong returned: ", conn.ping())


### PR DESCRIPTION
Modifies the client example to allow for an environment variable
(REDIS_SSL_DIR) to be used for specifying where they exist. Defaults to
`/etc/redis/ssl`.

Signed-off-by: Kyle Mestery <mestery@mestery.com>